### PR TITLE
Initialize Next.js app with Notion DB integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env.local and provide your Notion credentials
+NOTION_TOKEN=
+NOTION_DATABASE_ID=

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# notion-db-app
+# Notion DB App
+
+This is a simple Next.js application that connects to a Notion database using server components.
+
+## Setup
+
+1. Install dependencies (requires npm access):
+
+```bash
+npm install
+```
+
+If network access is restricted, you may need to manually download the dependencies.
+
+2. Copy `.env.example` to `.env.local` and fill in your Notion credentials:
+
+```
+NOTION_TOKEN=your_secret_integration_token
+NOTION_DATABASE_ID=your_database_id
+```
+
+3. Run the development server:
+
+```bash
+npm run dev
+```
+
+Visit `http://localhost:3000` to view the list of database items.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "notion-db-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@notionhq/client": "latest"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "latest",
+    "@types/node": "latest",
+    "eslint": "latest",
+    "eslint-config-next": "latest"
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,4 @@
+/* Global styles */
+body {
+  font-family: sans-serif;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,16 @@
+import { getDatabaseItems } from '@/lib/notion';
+
+export default async function HomePage() {
+  const items = await getDatabaseItems();
+
+  return (
+    <main>
+      <h1>Notion Database Items</h1>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>{item.title}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,0 +1,32 @@
+import { Client } from '@notionhq/client';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const databaseId = process.env.NOTION_DATABASE_ID as string;
+
+export interface DatabaseItem {
+  id: string;
+  title: string;
+}
+
+export async function getDatabaseItems(): Promise<DatabaseItem[]> {
+  if (!databaseId) {
+    console.warn('NOTION_DATABASE_ID is not defined');
+    return [];
+  }
+
+  const response = await notion.databases.query({
+    database_id: databaseId,
+  });
+
+  return response.results.map((page: any) => {
+    const titleProperty = page.properties.Name;
+    const title = Array.isArray(titleProperty.title)
+      ? titleProperty.title[0]?.plain_text || 'Untitled'
+      : 'Untitled';
+
+    return {
+      id: page.id,
+      title,
+    } as DatabaseItem;
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Next.js project skeleton with TypeScript
- add Notion client helper
- create server component to list database items
- document setup instructions and environment variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fed4ecf74832086c4159a1fd75712