### PR TITLE
Add Radix UI sample page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ npm run dev
 ```
 
 Visit `http://localhost:3000` to view the list of database items.
+For a simple Radix UI dialog example, open `http://localhost:3000/radix`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "@notionhq/client": "latest"
+    "@notionhq/client": "latest",
+    "@radix-ui/react-dialog": "latest"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/src/app/radix/page.tsx
+++ b/src/app/radix/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import * as Dialog from '@radix-ui/react-dialog';
+import './styles.css';
+
+export default function RadixPage() {
+  return (
+    <main>
+      <h1>Radix UI Dialog Example</h1>
+      <Dialog.Root>
+        <Dialog.Trigger asChild>
+          <button>Open Dialog</button>
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Overlay className="dialogOverlay" />
+          <Dialog.Content className="dialogContent">
+            <Dialog.Title>Hello from Radix UI</Dialog.Title>
+            <Dialog.Description>This is a sample dialog.</Dialog.Description>
+            <Dialog.Close asChild>
+              <button>Close</button>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </main>
+  );
+}

--- a/src/app/radix/styles.css
+++ b/src/app/radix/styles.css
@@ -1,0 +1,17 @@
+.dialogOverlay {
+  background-color: rgba(0, 0, 0, 0.4);
+  position: fixed;
+  inset: 0;
+}
+
+.dialogContent {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 90vw;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Summary
- add `@radix-ui/react-dialog` dependency
- document Radix sample page in README
- create `/radix` page showing a basic Dialog example

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683feee934e883209318e7bb7525b51d