### PR TITLE
Add Radix UI table for Notion database

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react": "latest",
     "react-dom": "latest",
     "@notionhq/client": "latest",
-    "@radix-ui/react-dialog": "latest"
+    "@radix-ui/react-dialog": "latest",
+    "@radix-ui/themes": "latest"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,14 @@
 import './globals.css';
+import '@radix-ui/themes/styles.css';
+import { Theme } from '@radix-ui/themes';
 import type { ReactNode } from 'react';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Theme>{children}</Theme>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { getDatabaseItems } from '@/lib/notion';
+import { Table } from '@radix-ui/themes';
 
 export default async function HomePage() {
   const items = await getDatabaseItems();
@@ -6,11 +7,20 @@ export default async function HomePage() {
   return (
     <main>
       <h1>Notion Database Items</h1>
-      <ul>
-        {items.map((item) => (
-          <li key={item.id}>{item.title}</li>
-        ))}
-      </ul>
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeaderCell>Title</Table.ColumnHeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {items.map((item) => (
+            <Table.Row key={item.id}>
+              <Table.Cell>{item.title}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
     </main>
   );
 }

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,7 +1,9 @@
 import { Client } from '@notionhq/client';
 
-const notion = new Client({ auth: process.env.NOTION_TOKEN });
-const databaseId = process.env.NOTION_DATABASE_ID as string;
+const notionToken = process.env.NOTION_TOKEN;
+const databaseId = process.env.NOTION_DATABASE_ID;
+
+export const notion = new Client({ auth: notionToken });
 
 export interface DatabaseItem {
   id: string;
@@ -14,14 +16,14 @@ export async function getDatabaseItems(): Promise<DatabaseItem[]> {
     return [];
   }
 
-  const response = await notion.databases.query({
+  const { results } = await notion.databases.query({
     database_id: databaseId,
   });
 
-  return response.results.map((page: any) => {
-    const titleProperty = page.properties.Name;
-    const title = Array.isArray(titleProperty.title)
-      ? titleProperty.title[0]?.plain_text || 'Untitled'
+  return results.map((page: any) => {
+    const name = page.properties?.Name;
+    const title = Array.isArray(name?.title) && name.title.length > 0
+      ? name.title[0].plain_text
       : 'Untitled';
 
     return {


### PR DESCRIPTION
## Summary
- fetch Notion database items with the official client
- display database entries using Radix UI `Table`
- include Radix Themes in layout
- add Radix themes dependency

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ff9c47a248320be6e4fe17596c4d1