### PR TITLE
Convert homepage to client component for SSR

### DIFF
--- a/src/app/api/items/route.ts
+++ b/src/app/api/items/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getDatabaseItems } from '@/lib/notion';
+
+export async function GET() {
+  try {
+    const items = await getDatabaseItems();
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to fetch items' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,27 @@
-import { getDatabaseItems } from '@/lib/notion';
+'use client';
+import { useEffect, useState } from 'react';
 import { Table } from '@radix-ui/themes';
+import { DatabaseItem } from '@/lib/notion';
 
-export default async function HomePage() {
-  const items = await getDatabaseItems();
+export default function HomePage() {
+  const [items, setItems] = useState<DatabaseItem[]>([]);
+
+  useEffect(() => {
+    async function fetchItems() {
+      try {
+        const res = await fetch('/api/items');
+        if (res.ok) {
+          const data = await res.json();
+          setItems(data);
+        } else {
+          console.error('Failed to fetch items');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchItems();
+  }, []);
 
   return (
     <main>


### PR DESCRIPTION
## Summary
- add API route for fetching Notion items
- turn `src/app/page.tsx` into a client component using `useEffect`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ffb5419b48320a5f72e71b03b4e56